### PR TITLE
Export `types` in `types.ts`.

### DIFF
--- a/lib/node/index.d.ts
+++ b/lib/node/index.d.ts
@@ -15,3 +15,4 @@ export { Transition } from './Transition';
 export { Instance } from './Instance';
 export { Visitor } from './Visitor';
 export { JSONSerializer } from './JSON';
+export { types } from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,3 +21,4 @@ export { Instance } from './Instance';
 
 export { Visitor } from './Visitor';
 export { JSONSerializer } from './JSON';
+export { types } from './types';


### PR DESCRIPTION
I could not import types in types.ts.
I faced into this problem when I made the wrapper of Class State.
So I exported the types in types.ts.